### PR TITLE
Made the config passphrase var sensitive

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "config_passphrase" {
   description = "Config passphrase."
   type        = string
+  sensitive   = true
 
   validation {
     condition     = can(regex("^.{0,32}$", var.config_passphrase))


### PR DESCRIPTION
This tag hides a variable from terraform command outputs and logs.